### PR TITLE
Improve Discord bot reliability and Claude Code integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ ALLOWED_USER_ID=your_discord_user_id
 # Base folder path where Claude Code will operate
 # Channel names will be appended to this path
 BASE_FOLDER=/Users/your-user-name/repos
+
+# MCP Server Port (optional, defaults to 3001)
+# Change this if port 3001 is already in use
+MCP_SERVER_PORT=3001

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage
 logs
 _.log
 report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+log.txt
 
 # dotenv environment variable files
 .env

--- a/README.md
+++ b/README.md
@@ -165,6 +165,29 @@ Bot: 🔧 LS (path: .)
 - Shows real-time tool usage and responses
 - Only responds to the configured `ALLOWED_USER_ID`
 
+## Troubleshooting
+
+### Claude Code Hooks
+
+If you have Claude Code hooks configured (e.g., audio notifications in `~/.claude/settings.json`), they may interfere with the Discord bot. The bot automatically sets `CLAUDE_DISABLE_HOOKS=1` when spawning Claude processes.
+
+To make your hooks respect this, add a check at the beginning of your hook scripts:
+
+```bash
+#!/bin/bash
+# Example: ~/.claude/claude-sound-notification.sh
+
+# Skip hook if running from Discord bot
+if [ "$CLAUDE_DISABLE_HOOKS" = "1" ]; then
+  exit 0
+fi
+
+# Your existing hook code (e.g., play sound)
+mplayer -really-quiet /path/to/sound.mp3
+```
+
+This ensures hooks run normally in your terminal but are skipped when using the Discord bot.
+
 For detailed setup instructions, troubleshooting, and development information, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License

--- a/mcp-bridge.cjs
+++ b/mcp-bridge.cjs
@@ -7,7 +7,8 @@ const { Transform } = require('stream');
 // Debug: Log environment variables at startup
 console.error(`MCP Bridge startup: DISCORD_CHANNEL_ID=${process.env.DISCORD_CHANNEL_ID}, DISCORD_CHANNEL_NAME=${process.env.DISCORD_CHANNEL_NAME}, DISCORD_USER_ID=${process.env.DISCORD_USER_ID}`);
 
-const MCP_SERVER_URL = 'http://localhost:3001/mcp';
+const MCP_SERVER_PORT = process.env.MCP_SERVER_PORT || '3001';
+const MCP_SERVER_URL = `http://localhost:${MCP_SERVER_PORT}/mcp`;
 
 // Transform stream to handle MCP messages
 const mcpTransform = new Transform({
@@ -48,7 +49,7 @@ const mcpTransform = new Transform({
 
     const options = {
       hostname: 'localhost',
-      port: 3001,
+      port: parseInt(MCP_SERVER_PORT),
       path: '/mcp',
       method: 'POST',
       headers

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -32,7 +32,9 @@ export function buildClaudeCommand(
     "--output-format",
     "stream-json",
     "--model",
-    "sonnet",
+    "claude-sonnet-4-5-20250929", // Latest Sonnet 4.5
+    "--permission-mode",
+    "acceptEdits", // Automatically accept edits without prompting
     "-p",
     escapedPrompt,
     "--verbose",
@@ -41,7 +43,7 @@ export function buildClaudeCommand(
   // Add session-specific MCP configuration
   commandParts.push("--mcp-config", sessionMcpConfigPath);
   commandParts.push("--permission-prompt-tool", "mcp__discord-permissions__approve_tool");
-  
+
   // Add allowed tools - we'll let the MCP server handle permissions
   commandParts.push("--allowedTools", "mcp__discord-permissions");
 
@@ -70,8 +72,9 @@ function createSessionMcpConfig(discordContext?: DiscordContext): string {
         command: "node",
         args: [bridgeScriptPath],
         env: {
+          MCP_SERVER_PORT: process.env.MCP_SERVER_PORT || "3001",
           DISCORD_CHANNEL_ID: discordContext?.channelId || "unknown",
-          DISCORD_CHANNEL_NAME: discordContext?.channelName || "unknown", 
+          DISCORD_CHANNEL_NAME: discordContext?.channelName || "unknown",
           DISCORD_USER_ID: discordContext?.userId || "unknown",
           DISCORD_MESSAGE_ID: discordContext?.messageId || ""
         }


### PR DESCRIPTION
This update enhances the Discord bot's reliability and fixes several issues:

**Core Improvements:**
- Update to Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)
- Add --permission-mode acceptEdits for autonomous operation
- Fix exit code 143 false error reporting (SIGTERM is normal shutdown)
- Add hook disabling mechanism for Discord bot sessions

**Bug Fixes:**
- Fix MCP bridge port mismatch (now uses MCP_SERVER_PORT env variable)
- Truncate long error messages to fit Discord's 4096 character limit
- Prevent sound notifications during Discord bot operations

**Configuration:**
- Add MCP_SERVER_PORT to environment configuration
- Pass port configuration through to MCP bridge
- Add CLAUDE_DISABLE_HOOKS environment variable

**Documentation:**
- Add troubleshooting section for Claude Code hooks
- Document MCP port configuration
- Add hook disabling instructions

**Testing:**
- Add tests for exit code handling (0, 143, and error codes)
- Improve test coverage for process lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for Claude Code Hooks interference with the Discord bot.

* **Improvements**
  * Discord messages now auto-truncate to fit embed size limits.
  * Enhanced bot reliability with improved process exit handling.
  * Configurable MCP server port (default: 3001).
  * Updated Claude model with automatic editing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->